### PR TITLE
feat: enable vulnerability alerts and lock file maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ Renovate configuration for Polarion Java Repos
 ## How to Use
 use `github>SchweizerischeBundesbahnen/casc-renovate-preset-polarion-java` in extends section of your `renovate.json` file.
 
+## Features
+
+This preset provides the following configuration for Polarion Java projects:
+
+### Security & Vulnerability Management
+- **Vulnerability Alerts**: Automatically creates PRs for dependencies with security vulnerabilities (including transitive dependencies)
+- **Lock File Maintenance**: Weekly updates (Mondays before 6am) to keep `package-lock.json` up-to-date with latest secure versions
+
+### Dependency Updates
+- **Maven**: Updates from SBB GitHub Packages and Maven Central, filtering out non-production versions
+- **npm**: Managed through vulnerability alerts and lock file maintenance
+- **Pre-commit hooks**: Keeps pre-commit hooks up to date
+
+### Automation
+- **Automerge**: Automatically merges non-major updates, dev dependencies, and pre-commit hooks after CI passes
+- **Semantic Commits**: Uses conventional commit messages
+- **Branch Automerge**: Merges directly to branch after CI passes (no merge commits)
+
 ## Developer Setup
 
 An editor capable of editing text file.

--- a/default.json
+++ b/default.json
@@ -8,6 +8,13 @@
     ":semanticCommits",
     ":enablePreCommit"
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
   "automergeType": "branch",
   "platformAutomerge": true,
   "prCreation": "not-pending",


### PR DESCRIPTION
## Summary

Enable Renovate to handle security vulnerabilities and transitive dependency updates across all Polarion Java projects, replacing Dependabot for consistent dependency security management.

## Changes

### default.json
- **vulnerabilityAlerts**: Creates PRs for dependencies with CVEs (including transitive dependencies)
- **lockFileMaintenance**: Weekly updates (Mondays before 6am) to refresh `package-lock.json`

### README.md
- Added **Features** section documenting all preset capabilities
- Documents security, dependency updates, and automation features

## Problem Solved

This addresses the issue where Renovate wasn't detecting security vulnerabilities in transitive npm dependencies (e.g., `glob@10.4.5` CVE-2025-64756 via `mocha`). Dependabot caught these, but using Renovate provides:

- ✅ Consistent tooling across all dependency types
- ✅ Configurable automerge policies
- ✅ Weekly lock file freshness
- ✅ Better integration with existing workflows

## DRY Principle

Following the DRY (Don't Repeat Yourself) principle, this PR does NOT override `npm.rangeStrategy` because:
- `vulnerabilityAlerts` already uses `'update-lockfile'` strategy for security PRs by default
- No need to change default behavior for regular npm updates
- Keeps configuration minimal and maintainable

## Impact

All repositories extending this preset will:
1. Get automatic PRs for security vulnerabilities (direct + transitive deps)
2. Receive weekly lock file updates to stay current with patches
3. Maintain default npm update behavior for non-security updates

## Testing

After merge, test in `ch.sbb.polarion.extension.pdf-exporter`:
1. Trigger Renovate manually or wait for next run
2. Verify PR created for `glob@10.4.5 → 10.5.0` (CVE-2025-64756)
3. Disable Dependabot security updates in affected repos

Related: SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter#6