### PR TITLE
refactor: drop redundant SBB automerge rule now covered by base preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,19 +33,6 @@
         "sbb"
       ],
       "enabled": false
-    },
-    {
-      "description": "SBB packages - Automerge minor/patch immediately",
-      "matchPackagePatterns": [
-        "^ch\\.sbb\\.",
-        "^python-sbb-polarion$"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
Removes the `SBB packages - Automerge minor/patch immediately` rule. It is now fully superseded by the base preset (`casc-renovate-preset-polarion`):

- 0-days exemption for `ch.sbb.*` → now provided by the base internal-SBB rule (across all update types).
- minor/patch automerge → already global in the base preset.

**No behavioural change** for Java repos. (The `ch.sbb` *major*-update no-longer-waiting effect comes from the base-preset addition itself, not from this removal.)

Depends on the base-preset PR (`casc-renovate-preset-polarion#2`); **merge that first**.

Validated with `renovate-config-validator@latest`.